### PR TITLE
created A5-38-08-CMD0x01 for Eltako FSR61NP

### DIFF
--- a/src/main/java/eu/aleon/aleoncean/device/SupportedDevice.java
+++ b/src/main/java/eu/aleon/aleoncean/device/SupportedDevice.java
@@ -18,6 +18,7 @@ package eu.aleon.aleoncean.device;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 
+import eu.aleon.aleoncean.device.local.LocalDeviceEEPA53808CMD01;
 import eu.aleon.aleoncean.device.local.LocalDeviceEEPA53808CMD02;
 import eu.aleon.aleoncean.device.local.LocalDeviceEEPF60201;
 import eu.aleon.aleoncean.device.local.LocalDeviceEEPF60202;
@@ -28,6 +29,7 @@ import eu.aleon.aleoncean.device.remote.RemoteDeviceEEPA50802;
 import eu.aleon.aleoncean.device.remote.RemoteDeviceEEPA51103;
 import eu.aleon.aleoncean.device.remote.RemoteDeviceEEPA51201;
 import eu.aleon.aleoncean.device.remote.RemoteDeviceEEPA52001;
+import eu.aleon.aleoncean.device.remote.RemoteDeviceEEPA53808CMD01;
 import eu.aleon.aleoncean.device.remote.RemoteDeviceEEPA53808CMD02;
 import eu.aleon.aleoncean.device.remote.RemoteDeviceEEPD20108;
 import eu.aleon.aleoncean.device.remote.RemoteDeviceEEPD50001;
@@ -44,6 +46,7 @@ import eu.aleon.aleoncean.device.remote.RemoteDeviceEEPF61001;
  * @author Markus Rathgeb {@literal <maggu2810@gmail.com>}
  */
 public enum SupportedDevice {
+    LD_A53808CMD1("LD_A5-38-08_CMD01", LocalDeviceEEPA53808CMD01.class),
     LD_A53808CMD2("LD_A5-38-08_CMD02", LocalDeviceEEPA53808CMD02.class),
     LD_F60201("LD_F6-02-01", LocalDeviceEEPF60201.class),
     LD_F60202("LD_F6-02-02", LocalDeviceEEPF60202.class),
@@ -54,6 +57,7 @@ public enum SupportedDevice {
     RD_A51103("RD_A5-11-03", RemoteDeviceEEPA51103.class),
     RD_A51201("RD_A5-12-01", RemoteDeviceEEPA51201.class),
     RD_A52001("RD_A5-20-01", RemoteDeviceEEPA52001.class),
+    RD_A53808CMD1("RD_A5-38-08_CMD01", RemoteDeviceEEPA53808CMD01.class),
     RD_A53808CMD2("RD_A5-38-08_CMD02", RemoteDeviceEEPA53808CMD02.class),
     RD_D20108("RD_D2-01-08", RemoteDeviceEEPD20108.class),
     RD_D50001("RD_D5-00-01", RemoteDeviceEEPD50001.class),

--- a/src/main/java/eu/aleon/aleoncean/device/local/LocalDeviceEEPA53808CMD01.java
+++ b/src/main/java/eu/aleon/aleoncean/device/local/LocalDeviceEEPA53808CMD01.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2014 aleon GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Note for all commercial users of this library:
+ * Please contact the EnOcean Alliance (http://www.enocean-alliance.org/)
+ * about a possible requirement to become member of the alliance to use the
+ * EnOcean protocol implementations.
+ *
+ * Contributors:
+ *    Markus Rathgeb - initial API and implementation and/or initial documentation
+ */
+package eu.aleon.aleoncean.device.local;
+
+import eu.aleon.aleoncean.device.*;
+import eu.aleon.aleoncean.packet.EnOceanId;
+import eu.aleon.aleoncean.packet.radio.userdata.eepa53808.UserDataEEPA53808CMD01;
+import eu.aleon.aleoncean.packet.radio.userdata.teachin4bs.UserData4BSTeachInVariant1;
+import eu.aleon.aleoncean.rxtx.ESP3Connector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * @author Markus Rathgeb {@literal <maggu2810@gmail.com>}
+ */
+public class LocalDeviceEEPA53808CMD01 extends StandardDevice implements RemoteDevice {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalDeviceEEPA53808CMD01.class);
+
+    private Boolean teachIn;
+    private Boolean on;
+
+    public LocalDeviceEEPA53808CMD01(final ESP3Connector conn, final EnOceanId addressRemote,
+                                     final EnOceanId addressLocal) {
+        super(conn, addressRemote, addressLocal);
+    }
+
+    public Boolean getTeachIn() {
+        return teachIn;
+    }
+
+    public void setTeachIn(final DeviceParameterUpdatedInitiation initiation, final Boolean newValue) {
+        final Boolean oldValue = this.teachIn;
+        this.teachIn = newValue;
+        fireParameterChanged(DeviceParameter.TEACHIN, initiation, oldValue, newValue);
+    }
+
+    public Boolean getOn() {
+        return on;
+    }
+
+    public void setOn(final DeviceParameterUpdatedInitiation initiation, final Boolean on) {
+        final Boolean old = this.on;
+        this.on = on;
+        fireParameterChanged(DeviceParameter.SWITCH, initiation, old, on);
+    }
+
+    private void sendPacket() {
+        if (teachIn == null || !teachIn) {
+            sendPacketData();
+        } else {
+            sendPacketTeachIn();
+        }
+    }
+
+    private void sendPacketTeachIn() {
+        final UserData4BSTeachInVariant1 userData = new UserData4BSTeachInVariant1();
+        send(userData);
+    }
+
+    private void sendPacketData() {
+        try {
+            final UserDataEEPA53808CMD01 userData = new UserDataEEPA53808CMD01();
+            userData.setTeachIn(false);
+
+            userData.setSwitchingCommand(getOn());
+
+            send(userData);
+        } catch (final NullPointerException ex) {
+            LOGGER.debug("Do not send data, caused by null value.");
+        }
+    }
+
+    @Override
+    protected void fillParameters(final Set<DeviceParameter> params) {
+        params.add(DeviceParameter.SWITCH);
+        params.add(DeviceParameter.TEACHIN);
+    }
+
+    @Override
+    public Object getByParameter(final DeviceParameter parameter) throws IllegalDeviceParameterException {
+        switch (parameter) {
+            case SWITCH:
+                return getOn();
+            case TEACHIN:
+                return getTeachIn();
+            default:
+                return super.getByParameter(parameter);
+        }
+    }
+
+    @Override
+    public void setByParameter(final DeviceParameter parameter, final Object value)
+            throws IllegalDeviceParameterException {
+        assert DeviceParameter.getSupportedClass(parameter).isAssignableFrom(value.getClass());
+        switch (parameter) {
+            case SWITCH:
+                setOn(DeviceParameterUpdatedInitiation.SET_PARAMETER, (Boolean) value);
+                sendPacket();
+                break;
+            case TEACHIN:
+                setTeachIn(DeviceParameterUpdatedInitiation.SET_PARAMETER, (Boolean) value);
+                sendPacket();
+                break;
+            default:
+                super.setByParameter(parameter, value);
+                break;
+        }
+    }
+
+}

--- a/src/main/java/eu/aleon/aleoncean/device/remote/RemoteDeviceEEPA53808CMD01.java
+++ b/src/main/java/eu/aleon/aleoncean/device/remote/RemoteDeviceEEPA53808CMD01.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2014 aleon GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Note for all commercial users of this library:
+ * Please contact the EnOcean Alliance (http://www.enocean-alliance.org/)
+ * about a possible requirement to become member of the alliance to use the
+ * EnOcean protocol implementations.
+ *
+ * Contributors:
+ *    Markus Rathgeb - initial API and implementation and/or initial documentation
+ */
+package eu.aleon.aleoncean.device.remote;
+
+import eu.aleon.aleoncean.device.*;
+import eu.aleon.aleoncean.packet.EnOceanId;
+import eu.aleon.aleoncean.packet.radio.RadioPacket4BS;
+import eu.aleon.aleoncean.packet.radio.userdata.UserDataScaleValueException;
+import eu.aleon.aleoncean.packet.radio.userdata.eepa53808.UserDataEEPA53808CMD01;
+import eu.aleon.aleoncean.rxtx.ESP3Connector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * @author Markus Rathgeb {@literal <maggu2810@gmail.com>}
+ */
+public class RemoteDeviceEEPA53808CMD01 extends StandardDevice implements RemoteDevice {
+
+    private final Logger logger = LoggerFactory.getLogger(RemoteDeviceEEPA53808CMD01.class);
+
+    private Boolean on;
+
+    public RemoteDeviceEEPA53808CMD01(final ESP3Connector conn, final EnOceanId addressRemote,
+                                      final EnOceanId addressLocal) {
+        super(conn, addressRemote, addressLocal);
+    }
+
+    @Override
+    protected void parseRadioPacket4BS(final RadioPacket4BS packet) {
+        final UserDataEEPA53808CMD01 userData = new UserDataEEPA53808CMD01(packet.getUserDataRaw());
+
+        setOn(DeviceParameterUpdatedInitiation.RADIO_PACKET, new Boolean(userData.getSwitchingCommand()));
+    }
+
+    @Override
+    protected void fillParameters(final Set<DeviceParameter> params) {
+        params.add(DeviceParameter.SWITCH);
+    }
+
+    @Override
+    public Object getByParameter(final DeviceParameter parameter) throws IllegalDeviceParameterException {
+        switch (parameter) {
+            case SWITCH:
+                return getOn();
+            default:
+                return super.getByParameter(parameter);
+        }
+    }
+
+    @Override
+    public void setByParameter(final DeviceParameter parameter, final Object value)
+            throws IllegalDeviceParameterException {
+        assert DeviceParameter.getSupportedClass(parameter).isAssignableFrom(value.getClass());
+        switch (parameter) {
+            case SWITCH:
+                setOn(DeviceParameterUpdatedInitiation.SET_PARAMETER, (Boolean) value);
+                break;
+            default:
+                super.setByParameter(parameter, value);
+                break;
+        }
+    }
+
+    public Boolean getOn() {
+        return on;
+    }
+
+    public void setOn(final DeviceParameterUpdatedInitiation initiation, final Boolean on) {
+        final Boolean old = this.on;
+        this.on = on;
+        fireParameterChanged(DeviceParameter.SWITCH, initiation, old, on);
+    }
+
+}

--- a/src/main/java/eu/aleon/aleoncean/packet/radio/userdata/eepa53808/UserDataEEPA53808CMD01.java
+++ b/src/main/java/eu/aleon/aleoncean/packet/radio/userdata/eepa53808/UserDataEEPA53808CMD01.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014 aleon GmbH.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Note for all commercial users of this library:
+ * Please contact the EnOcean Alliance (http://www.enocean-alliance.org/)
+ * about a possible requirement to become member of the alliance to use the
+ * EnOcean protocol implementations.
+ *
+ * Contributors:
+ *    Markus Rathgeb - initial API and implementation and/or initial documentation
+ */
+package eu.aleon.aleoncean.packet.radio.userdata.eepa53808;
+
+import eu.aleon.aleoncean.packet.radio.userdata.UserDataScaleValueException;
+import eu.aleon.aleoncean.util.Bits;
+
+/**
+ * @author Markus Rathgeb {@literal <maggu2810@gmail.com>}
+ */
+public class UserDataEEPA53808CMD01 extends UserDataEEPA53808 {
+
+    public static final byte CMD = UserDataEEPA53808.CMD_SWITCHING;
+
+    private static final int OFFSET_STR = 30;
+    private static final int LENGTH_STR = 1;
+
+    private static final int OFFSET_SW = 31;
+    private static final int LENGTH_SW = 1;
+
+    public UserDataEEPA53808CMD01() {
+        super(CMD);
+    }
+
+    public UserDataEEPA53808CMD01(final byte[] data) {
+        super(data);
+    }
+
+    public boolean getStoreFinalValue() {
+        final long raw = Bits.getBitsFromBytes(getUserData(), OFFSET_STR, LENGTH_STR);
+        return raw != 0;
+    }
+
+    public void setStoreFinalValue(final boolean value) {
+        Bits.setBitsOfBytes(value ? 1 : 0, getUserData(), OFFSET_STR, LENGTH_STR);
+    }
+
+    public boolean getSwitchingCommand() {
+        final long raw = Bits.getBitsFromBytes(getUserData(), OFFSET_SW, LENGTH_SW);
+        return raw != 0;
+    }
+
+    public void setSwitchingCommand(final boolean value) {
+        Bits.setBitsOfBytes(value ? 1 : 0, getUserData(), OFFSET_SW, LENGTH_SW);
+    }
+
+}

--- a/src/main/java/eu/aleon/aleoncean/packet/radio/userdata/eepa53808/UserDataEEPA53808Factory.java
+++ b/src/main/java/eu/aleon/aleoncean/packet/radio/userdata/eepa53808/UserDataEEPA53808Factory.java
@@ -24,6 +24,9 @@ public class UserDataEEPA53808Factory {
         final UserDataEEPA53808 userData;
 
         switch (UserDataEEPA53808.getCommandId(raw)) {
+            case UserDataEEPA53808CMD01.CMD:
+                userData = new UserDataEEPA53808CMD01(raw);
+                break;
             case UserDataEEPA53808CMD02.CMD:
                 userData = new UserDataEEPA53808CMD02(raw);
                 break;


### PR DESCRIPTION
I tried to create an EEP A5-38-08-CMD0x01 for Eltako FSR61NP.
This is an switch-actor (no dimmer).
It should work - but it doesn't for me...

My Item-Definition:
```
Switch FSR61_19602FD_TEACHIN  "Aktor 2 19602FD (TEACH IN)"     (Eltako) {aleoncean="LOCALID=01:96:02:FD,TYPE=LD_A5-38-08_CMD01,PARAMETER=TEACHIN"}
Switch FSR61_19602FD_SEND_SW  "Aktor 2 19602FD [%s]" (Eltako)  {aleoncean="LOCALID=01:96:02:FD,TYPE=LD_A5-38-08_CMD01,PARAMETER=SWITCH"}
```

but it throws errors and warnings:
```
17:17:16.392 [ERROR] [org.openhab.binding.aleoncean       ] - [org.openhab.binding.aleoncean.binding(179)] The addBindingProviderRef method has thrown an exception
java.lang.ClassCastException: org.openhab.binding.aleoncean.internal.AleonceanGenericBindingProvider cannot be cast to org.openhab.binding.aleoncean.internal.AleonceanGenericBindingProvider
        at org.openhab.binding.aleoncean.internal.AleonceanBinding.allBindingsChanged(AleonceanBinding.java:228)
        at org.openhab.core.binding.AbstractBinding.addBindingProvider(AbstractBinding.java:61)
        at org.openhab.binding.aleoncean.internal.AleonceanBinding.addBindingProviderRef(AleonceanBinding.java:191)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)[:1.8.0_91]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)[:1.8.0_91]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)[:1.8.0_91]
        at java.lang.reflect.Method.invoke(Method.java:498)[:1.8.0_91]
        at org.apache.felix.scr.impl.helper.BaseMethod.invokeMethod(BaseMethod.java:222)
        at org.apache.felix.scr.impl.helper.BaseMethod.access$500(BaseMethod.java:37)
        at org.apache.felix.scr.impl.helper.BaseMethod$Resolved.invoke(BaseMethod.java:615)
        at org.apache.felix.scr.impl.helper.BaseMethod.invoke(BaseMethod.java:499)
        at org.apache.felix.scr.impl.helper.BindMethod.invoke(BindMethod.java:41)
        at org.apache.felix.scr.impl.manager.DependencyManager.doInvokeBindMethod(DependencyManager.java:1660)
        at org.apache.felix.scr.impl.manager.DependencyManager.open(DependencyManager.java:1495)
        at org.apache.felix.scr.impl.manager.SingleComponentManager.createImplementationObject(SingleComponentManager.java:265)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.SingleComponentManager.createComponent(SingleComponentManager.java:113)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.SingleComponentManager.getService(SingleComponentManager.java:866)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.SingleComponentManager.getServiceInternal(SingleComponentManager.java:833)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.SingleComponentManager.getService(SingleComponentManager.java:774)[33:org.apache.felix.scr:2.0.2]
        at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse$1.run(ServiceFactoryUse.java:212)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at java.security.AccessController.doPrivileged(Native Method)[:1.8.0_91]
        at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.factoryGetService(ServiceFactoryUse.java:210)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceFactoryUse.getService(ServiceFactoryUse.java:111)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceConsumer$2.getService(ServiceConsumer.java:45)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.getService(ServiceRegistrationImpl.java:496)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.getService(ServiceRegistry.java:461)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.getService(BundleContextImpl.java:619)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at com.eclipsesource.jaxrs.publisher.internal.ResourceTracker.addingService(ResourceTracker.java:39)[11:com.eclipsesource.jaxrs.publisher:5.3.1.201602281253]
        at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:941)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.ServiceTracker$Tracked.customizerAdding(ServiceTracker.java:870)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.AbstractTracked.track(AbstractTracked.java:229)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:901)[org.osgi.core-6.0.0.jar:]
        at org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener.serviceChanged(FilteredServiceListener.java:109)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:914)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEventPrivileged(ServiceRegistry.java:862)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEvent(ServiceRegistry.java:801)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.register(ServiceRegistrationImpl.java:127)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.registerService(ServiceRegistry.java:225)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:464)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.register(AbstractComponentManager.java:869)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.register(AbstractComponentManager.java:857)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.RegistrationManager.changeRegistration(RegistrationManager.java:133)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.registerService(AbstractComponentManager.java:915)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.activateInternal(AbstractComponentManager.java:715)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.enable(AbstractComponentManager.java:399)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.config.ConfigurableComponentHolder.enableComponents(ConfigurableComponentHolder.java:676)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.BundleComponentActivator.initialEnable(BundleComponentActivator.java:339)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.Activator.loadComponents(Activator.java:360)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.Activator.access$000(Activator.java:53)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.Activator$ScrExtension.start(Activator.java:260)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.utils.extender.AbstractExtender.createExtension(AbstractExtender.java:259)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.utils.extender.AbstractExtender.modifiedBundle(AbstractExtender.java:232)[33:org.apache.felix.scr:2.0.2]
        at org.osgi.util.tracker.BundleTracker$Tracked.customizerModified(BundleTracker.java:482)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.BundleTracker$Tracked.customizerModified(BundleTracker.java:415)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.AbstractTracked.track(AbstractTracked.java:232)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.BundleTracker$Tracked.bundleChanged(BundleTracker.java:444)[org.osgi.core-6.0.0.jar:]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:902)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEventPrivileged(EquinoxEventPublisher.java:165)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:75)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:67)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor.publishModuleEvent(EquinoxContainerAdaptor.java:102)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.Module.publishEvent(Module.java:466)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.Module.start(Module.java:457)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1582)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1562)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1533)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1476)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:340)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
17:17:16.523 [ERROR] [org.openhab.binding.aleoncean       ] - [org.openhab.binding.aleoncean.binding(177)] The addBindingProviderRef method has thrown an exception
java.lang.ClassCastException: org.openhab.binding.aleoncean.internal.AleonceanGenericBindingProvider cannot be cast to org.openhab.binding.aleoncean.internal.AleonceanGenericBindingProvider
        at org.openhab.binding.aleoncean.internal.AleonceanBinding.allBindingsChanged(AleonceanBinding.java:228)
        at org.openhab.core.binding.AbstractBinding.addBindingProvider(AbstractBinding.java:61)
        at org.openhab.binding.aleoncean.internal.AleonceanBinding.addBindingProviderRef(AleonceanBinding.java:191)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)[:1.8.0_91]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)[:1.8.0_91]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)[:1.8.0_91]
        at java.lang.reflect.Method.invoke(Method.java:498)[:1.8.0_91]
        at org.apache.felix.scr.impl.helper.BaseMethod.invokeMethod(BaseMethod.java:222)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.helper.BaseMethod.access$500(BaseMethod.java:37)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.helper.BaseMethod$Resolved.invoke(BaseMethod.java:615)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.helper.BaseMethod.invoke(BaseMethod.java:499)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.helper.BindMethod.invoke(BindMethod.java:41)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.DependencyManager.doInvokeBindMethod(DependencyManager.java:1660)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.DependencyManager.invokeBindMethod(DependencyManager.java:1636)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.SingleComponentManager.invokeBindMethod(SingleComponentManager.java:370)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.DependencyManager$MultipleDynamicCustomizer.addedService(DependencyManager.java:319)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.DependencyManager$MultipleDynamicCustomizer.addedService(DependencyManager.java:295)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerAdded(ServiceTracker.java:1215)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.customizerAdded(ServiceTracker.java:1136)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.ServiceTracker$AbstractTracked.trackAdding(ServiceTracker.java:945)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.ServiceTracker$AbstractTracked.track(ServiceTracker.java:881)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.ServiceTracker$Tracked.serviceChanged(ServiceTracker.java:1167)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.BundleComponentActivator$ListenerInfo.serviceChanged(BundleComponentActivator.java:120)[33:org.apache.felix.scr:2.0.2]
        at org.eclipse.osgi.internal.serviceregistry.FilteredServiceListener.serviceChanged(FilteredServiceListener.java:109)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:914)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEventPrivileged(ServiceRegistry.java:862)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.publishServiceEvent(ServiceRegistry.java:801)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistrationImpl.register(ServiceRegistrationImpl.java:127)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.serviceregistry.ServiceRegistry.registerService(ServiceRegistry.java:225)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.registerService(BundleContextImpl.java:464)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.register(AbstractComponentManager.java:869)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager$3.register(AbstractComponentManager.java:857)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.RegistrationManager.changeRegistration(RegistrationManager.java:133)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.registerService(AbstractComponentManager.java:915)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.activateInternal(AbstractComponentManager.java:715)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.manager.AbstractComponentManager.enable(AbstractComponentManager.java:399)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.config.ConfigurableComponentHolder.enableComponents(ConfigurableComponentHolder.java:676)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.BundleComponentActivator.initialEnable(BundleComponentActivator.java:339)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.Activator.loadComponents(Activator.java:360)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.Activator.access$000(Activator.java:53)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.scr.impl.Activator$ScrExtension.start(Activator.java:260)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.utils.extender.AbstractExtender.createExtension(AbstractExtender.java:259)[33:org.apache.felix.scr:2.0.2]
        at org.apache.felix.utils.extender.AbstractExtender.modifiedBundle(AbstractExtender.java:232)[33:org.apache.felix.scr:2.0.2]
        at org.osgi.util.tracker.BundleTracker$Tracked.customizerModified(BundleTracker.java:482)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.BundleTracker$Tracked.customizerModified(BundleTracker.java:415)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.AbstractTracked.track(AbstractTracked.java:232)[org.osgi.core-6.0.0.jar:]
        at org.osgi.util.tracker.BundleTracker$Tracked.bundleChanged(BundleTracker.java:444)[org.osgi.core-6.0.0.jar:]
        at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:902)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEventPrivileged(EquinoxEventPublisher.java:165)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:75)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:67)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor.publishModuleEvent(EquinoxContainerAdaptor.java:102)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.Module.publishEvent(Module.java:466)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.Module.start(Module.java:457)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1582)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1562)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1533)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1476)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
        at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:340)[org.eclipse.osgi-3.10.2.v20150203-1939.jar:]
117:17:16.605 [INFO ] [ing.aleoncean.internal.worker.Worker] - Chip ID: 01:96:36:65
17:17:16.777 [INFO ] [ing.aleoncean.internal.worker.Worker] - Base ID: FF:9B:32:80, remaining write cycles: 10
17:17:16.781 [WARN ] [.aleoncean.internal.AleonceanBinding] - You need to set at least the port for ESP3 hardware if you want to use the aleoncean binding.
17:17:17.781 [WARN ] [.aleoncean.internal.AleonceanBinding] - Binding provider is not an instance of AleonceanGenericBindingProvider.

```
